### PR TITLE
fix deprecated warnings for gcc

### DIFF
--- a/Include/raknet/NetworkTypes.h
+++ b/Include/raknet/NetworkTypes.h
@@ -77,12 +77,7 @@ namespace RakNet
 		// Sets the binary address part from a string.  Doesn't set the port
 		void SetBinaryAddress(const char *str);
 
-		PlayerID& operator = ( const PlayerID& input )
-		{
-			binaryAddress = input.binaryAddress;
-			port = input.port;
-			return *this;
-		}
+		PlayerID &operator=(const PlayerID &input) = default;
 
 		bool operator==( const PlayerID& right ) const;
 		bool operator!=( const PlayerID& right ) const;
@@ -103,7 +98,7 @@ namespace RakNet
 		PlayerID playerId;
 		unsigned short localSystemId;
 
-		NetworkID& operator = ( const NetworkID& input );
+		NetworkID& operator = ( const NetworkID& input ) = default;
 
 		static bool IsPeerToPeerMode(void);
 		static void SetPeerToPeerMode(bool isPeerToPeer);

--- a/Source/NetworkTypes.cpp
+++ b/Source/NetworkTypes.cpp
@@ -84,6 +84,13 @@ char* my_itoa( int value, char* result, int base ) {
 // All systems must use the same value for this variable.
 bool RAK_DLL_EXPORT NetworkID::peerToPeerMode=false;
 
+PlayerID& PlayerID::operator = ( const PlayerID& input )
+{
+	binaryAddress = input.binaryAddress;
+	port = input.port;
+	return *this;
+}
+
 bool PlayerID::operator==( const PlayerID& right ) const
 {
 	return binaryAddress == right.binaryAddress && port == right.port;


### PR DESCRIPTION
fixes warning that gcc show for copying constructor which is deprecated.

example:
```
error: implicitly-declared ‘constexpr RakNet::PlayerID::PlayerID(const RakNet::PlayerID&)’ is deprecated [-Werror=deprecated-copy]
```