### PR TITLE
Fixed: lingering player, invalid player IDs and server crash after client exceeds a sa-mp network limit.

### DIFF
--- a/Source/RakPeer.cpp
+++ b/Source/RakPeer.cpp
@@ -4224,7 +4224,7 @@ namespace RakNet
 				const char* playerIp = rakPeer->PlayerIDToDottedIP(playerId);
 				RakNetTime banTime = SAMPRakNet::GetNetworkLimitsBanTime();
 				rakPeer->AddToBanList(playerIp, banTime);
-				rakPeer->CloseConnectionInternal(playerId, false, true, 0);
+				return;
 			}
 		}
 		else


### PR DESCRIPTION
If a client exceeds a sa-mp network limit (e.g. messageholelimit), the connection is banned and is immediately closed in RakNet internally, which means the open.mp server is not notified. This leads to three issues. First, the player concerned will remain lingering and keeps occupying a player slot. Second, once all slots are taken, newly connected players are assigned player ID -1. Third, because of missing checks for invalid player ID's in the open.mp server, the server may crash after a while. This commit fixes all issues by removing the instant disconnection but keeping the ban in place.