### PR TITLE
Fixed: zombie players

### DIFF
--- a/Source/RakPeer.cpp
+++ b/Source/RakPeer.cpp
@@ -4224,7 +4224,7 @@ namespace RakNet
 				const char* playerIp = rakPeer->PlayerIDToDottedIP(playerId);
 				RakNetTime banTime = SAMPRakNet::GetNetworkLimitsBanTime();
 				rakPeer->AddToBanList(playerIp, banTime);
-				rakPeer->CloseConnectionInternal(playerId, false, true, 0);
+				return;
 			}
 		}
 		else


### PR DESCRIPTION
If a player exceeds a network limit (e.g. messageholelimit), the player's IP is banned and the connection is immediately closed by RakNet internally. The open.mp server is by design not notified of connections closed internally by RakNet. This causes three issues. First, the player concerned will remain connected in open.mp as a zombie player. Second, once all player IDs are taken, new players are assigned player ID -1. Third, due to missing array boundary checks in the open.mp server at several places, the server will crash when trying to access an array at index -1. This commit fixes all issues by banning the IP only, which results in a connection time out, of which the open.mp server is notified, which deletes the player accordingly.