### PR TITLE
Add client-side support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if (WIN32)
 endif()
 
 if (RAKNET_BUILD_FOR_CLIENT)
-	target_compile_definitions(raknet PUBLIC -DBUILD_FOR_CLIENT)
+	target_compile_definitions(raknet PUBLIC -DRAKNET_BUILD_FOR_CLIENT)
 else()
 	target_link_libraries(raknet OMP-SDK)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(RAKNET_BUILD_FOR_CLIENT "Build RakNet without server-side functionality" NO)
+
 if(WIN32)
 	add_definitions(
 		-D_CRT_SECURE_NO_WARNINGS
@@ -50,7 +52,11 @@ target_include_directories(raknet
 )
 
 if (WIN32)
-	target_link_libraries(raknet Ws2_32 OMP-SDK)
+	target_link_libraries(raknet Ws2_32)
+endif()
+
+if (RAKNET_BUILD_FOR_CLIENT)
+	target_compile_definitions(raknet PUBLIC -DBUILD_FOR_CLIENT)
 else()
 	target_link_libraries(raknet OMP-SDK)
 endif()

--- a/Include/raknet/NetworkTypes.h
+++ b/Include/raknet/NetworkTypes.h
@@ -20,7 +20,10 @@
 
 #include "RakNetDefines.h"
 #include "Export.h"
+#ifndef BUILD_FOR_CLIENT
 #include "../../SDK/include/types.hpp"
+#endif
+#include <functional>
 
 /// Forward declaration
 namespace RakNet

--- a/Include/raknet/NetworkTypes.h
+++ b/Include/raknet/NetworkTypes.h
@@ -20,7 +20,7 @@
 
 #include "RakNetDefines.h"
 #include "Export.h"
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 #include "../../SDK/include/types.hpp"
 #endif
 #include <functional>

--- a/Include/raknet/RakPeer.h
+++ b/Include/raknet/RakPeer.h
@@ -18,6 +18,8 @@
 #ifndef __RAK_PEER_H
 #define __RAK_PEER_H
 
+#include <unordered_map>
+
 #include "Export.h"
 #include "RakPeerInterface.h"
 #include "ReliabilityLayer.h"
@@ -508,7 +510,9 @@ namespace RakNet
 			bool setAESKey; /// true if security is enabled.
 			RPCMap rpcMap; /// Mapping of RPC calls to single byte integers to save transmission bandwidth.
 			enum ConnectMode {NO_ACTION, DISCONNECT_ASAP, DISCONNECT_ASAP_SILENTLY, DISCONNECT_ON_NO_ACK, REQUESTED_CONNECTION, HANDLING_CONNECTION_REQUEST, UNVERIFIED_SENDER, SET_ENCRYPTION_ON_MULTIPLE_16_BYTE_PACKET, CONNECTED} connectMode;
+#ifndef BUILD_FOR_CLIENT
 			SAMPRakNet::RemoteSystemData sampData;
+#endif
 			bool isLogon;
 		};
 
@@ -529,7 +533,9 @@ namespace RakNet
 		friend void* UpdateNetworkLoop( void* arguments );
 	#endif
 
+#ifndef BUILD_FOR_CLIENT
 		friend bool __stdcall ProcessBan(RakPeer* rakPeer, PlayerID playerId, const char* data, const int length);
+#endif
 
 		// This is done to provide custom RPC handling when in a blocking RPC
 		Packet* ReceiveIgnoreRPC( void );
@@ -543,11 +549,13 @@ namespace RakNet
 		/// \return 0 if none
 		RemoteSystemStruct *GetRemoteSystemFromPlayerID( const PlayerID playerID, bool calledFromNetworkThread, bool onlyActive) const;
 		///Parse out a connection request packet
+#ifndef BUILD_FOR_CLIENT
 		void ParseConnectionRequestPacket( RakPeer::RemoteSystemStruct *remoteSystem, PlayerID playerId, const char *data, int byteSize);
 		bool ParseConnectionAuthPacket(RakPeer::RemoteSystemStruct* remoteSystem, PlayerID playerId, unsigned char* data, int byteSize);
 		///When we get a connection request from an ip / port, accept it unless full
 		void OnConnectionRequest( RakPeer::RemoteSystemStruct *remoteSystem, unsigned char *AESKey, bool setAESKey );
 		void AcceptConnectionRequest(RakPeer::RemoteSystemStruct* remoteSystem);
+#endif
 		///Send a reliable disconnect packet to this player and disconnect them when it is delivered
 		void NotifyAndFlagForDisconnect( const PlayerID playerId, bool performImmediate, unsigned char orderingChannel );
 		///Returns how many remote systems initiated a connection to us
@@ -602,7 +610,7 @@ namespace RakNet
 
 		/// open.mp addition:
 		/// Let's create an array of player indexes using PlayerIDs
-		FlatHashMap<PlayerID, int> playerIndexes;
+		std::unordered_map<PlayerID, int> playerIndexes;
 
 		/// This is an array of pointers to RemoteSystemStruct
 		/// This allows us to preallocate the list when starting, so we don't have to allocate or delete at runtime.

--- a/Include/raknet/RakPeer.h
+++ b/Include/raknet/RakPeer.h
@@ -18,8 +18,6 @@
 #ifndef __RAK_PEER_H
 #define __RAK_PEER_H
 
-#include <unordered_map>
-
 #include "Export.h"
 #include "RakPeerInterface.h"
 #include "ReliabilityLayer.h"

--- a/Include/raknet/RakPeer.h
+++ b/Include/raknet/RakPeer.h
@@ -510,7 +510,7 @@ namespace RakNet
 			bool setAESKey; /// true if security is enabled.
 			RPCMap rpcMap; /// Mapping of RPC calls to single byte integers to save transmission bandwidth.
 			enum ConnectMode {NO_ACTION, DISCONNECT_ASAP, DISCONNECT_ASAP_SILENTLY, DISCONNECT_ON_NO_ACK, REQUESTED_CONNECTION, HANDLING_CONNECTION_REQUEST, UNVERIFIED_SENDER, SET_ENCRYPTION_ON_MULTIPLE_16_BYTE_PACKET, CONNECTED} connectMode;
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			SAMPRakNet::RemoteSystemData sampData;
 #endif
 			bool isLogon;
@@ -533,7 +533,7 @@ namespace RakNet
 		friend void* UpdateNetworkLoop( void* arguments );
 	#endif
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		friend bool __stdcall ProcessBan(RakPeer* rakPeer, PlayerID playerId, const char* data, const int length);
 #endif
 
@@ -549,7 +549,7 @@ namespace RakNet
 		/// \return 0 if none
 		RemoteSystemStruct *GetRemoteSystemFromPlayerID( const PlayerID playerID, bool calledFromNetworkThread, bool onlyActive) const;
 		///Parse out a connection request packet
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		void ParseConnectionRequestPacket( RakPeer::RemoteSystemStruct *remoteSystem, PlayerID playerId, const char *data, int byteSize);
 		bool ParseConnectionAuthPacket(RakPeer::RemoteSystemStruct* remoteSystem, PlayerID playerId, unsigned char* data, int byteSize);
 		///When we get a connection request from an ip / port, accept it unless full

--- a/Include/raknet/RakServer.h
+++ b/Include/raknet/RakServer.h
@@ -435,7 +435,7 @@ namespace RakNet
 		/// \sa RakNetStatistics.h
 		RakNetStatisticsStruct * GetStatistics( const PlayerID playerId ) override;
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		/// Return the SAMPRakNet RemoteSystemData for a player ID
 		virtual SAMPRakNet::RemoteSystemData GetSAMPDataFromPlayerID(const PlayerID playerId) override;
 #endif

--- a/Include/raknet/RakServer.h
+++ b/Include/raknet/RakServer.h
@@ -435,8 +435,10 @@ namespace RakNet
 		/// \sa RakNetStatistics.h
 		RakNetStatisticsStruct * GetStatistics( const PlayerID playerId ) override;
 
+#ifndef BUILD_FOR_CLIENT
 		/// Return the SAMPRakNet RemoteSystemData for a player ID
 		virtual SAMPRakNet::RemoteSystemData GetSAMPDataFromPlayerID(const PlayerID playerId) override;
+#endif
 
 		/// Get Remote System data for a player from their ID
 		virtual RakPeer::RemoteSystemStruct* GetRemoteSystemFromPlayerID(const PlayerID playerId) override;

--- a/Include/raknet/RakServerInterface.h
+++ b/Include/raknet/RakServerInterface.h
@@ -429,8 +429,10 @@ namespace RakNet
 		/// \sa RakNetStatistics.h
 		virtual RakNetStatisticsStruct * GetStatistics( const PlayerID playerId )=0;
 
+#ifndef BUILD_FOR_CLIENT
 		/// Get SAMP data for a player from their ID
 		virtual SAMPRakNet::RemoteSystemData GetSAMPDataFromPlayerID(const PlayerID playerId) = 0;
+#endif
 
 		/// Get Remote System data for a player from their ID
 		virtual RakPeer::RemoteSystemStruct* GetRemoteSystemFromPlayerID(const PlayerID playerId) = 0;

--- a/Include/raknet/RakServerInterface.h
+++ b/Include/raknet/RakServerInterface.h
@@ -429,7 +429,7 @@ namespace RakNet
 		/// \sa RakNetStatistics.h
 		virtual RakNetStatisticsStruct * GetStatistics( const PlayerID playerId )=0;
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		/// Get SAMP data for a player from their ID
 		virtual SAMPRakNet::RemoteSystemData GetSAMPDataFromPlayerID(const PlayerID playerId) = 0;
 #endif

--- a/SAMPRakNet.cpp
+++ b/SAMPRakNet.cpp
@@ -591,9 +591,9 @@ SAMPRakNet::
         // Alternate the mask every byte.
         cur = (uint8_t)src[i];
         checksum ^= cur & 0xAA;
+        cur = key[cur];
         if (i & 1)
             cur ^= port;
-        cur = key[cur];
         buffer_[i + 1] = cur;
     }
     buffer_[0] = checksum;

--- a/SAMPRakNet.cpp
+++ b/SAMPRakNet.cpp
@@ -9,19 +9,19 @@
 #include <PacketEnumerations.h>
 
 uint8_t SAMPRakNet::buffer_[MAXIMUM_MTU_SIZE];
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 char SAMPRakNet::authkeyBuffer_[AUTHKEY_RESPONSE_LEN];
 bool SAMPRakNet::connectAsNpc_ = false;
 #endif
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 uint32_t SAMPRakNet::token_;
 #endif
 uint16_t SAMPRakNet::portNumber = 7777;
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 Query* SAMPRakNet::query_ = nullptr;
 #endif
 unsigned int SAMPRakNet::timeout_ = 10000;
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 unsigned int SAMPRakNet::minConnectionTime_ = 0;
 unsigned int SAMPRakNet::messagesLimit_ = 500;
 unsigned int SAMPRakNet::messageHoleLimit_ = 3000;
@@ -610,7 +610,7 @@ SAMPRakNet::
     return buffer_;
 }
 
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 inline uint8_t transformAuthSha1(const uint8_t value, const uint8_t xorValue)
 {
     static const uint8_t authHashTransformTable[] = {
@@ -705,7 +705,7 @@ SAMPRakNet::
 }
 #endif
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 void SAMPRakNet::
     HandleQuery(SOCKET instance, int outsize, const sockaddr_in& client, char const* buf, int insize)
 {

--- a/SAMPRakNet.hpp
+++ b/SAMPRakNet.hpp
@@ -24,11 +24,11 @@ typedef int SOCKET;
 
 #define MAX_AUTH_RESPONSE_LEN (64)
 
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 #define AUTHKEY_RESPONSE_LEN (40)
 #endif
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 #include "../../Server/Components/LegacyNetwork/Query/query.hpp"
 #endif
 
@@ -42,7 +42,7 @@ typedef int SOCKET;
 class SAMPRakNet
 {
 public:
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	enum AuthType {
 		AuthType_Invalid,
 		AuthType_Player,
@@ -70,11 +70,11 @@ public:
 	static uint16_t GetPort();
 	static void SetPort(uint16_t value);
 
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 	static char * PrepareAuthkeyResponse(const char* initialKey);
 #endif
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	static uint32_t GetToken() { return token_; }
 	static void SeedToken() { token_ = rand(); }
 
@@ -90,12 +90,12 @@ public:
 	static void SetTimeout(unsigned int timeout) { timeout_ = timeout; }
 	static unsigned int GetTimeout() { return timeout_; }
 
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 	static void SetConnectionAsNpc(bool enabled) { connectAsNpc_ = enabled; }
 	static bool ShouldConnectAsNpc() { return connectAsNpc_; }
 #endif
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	static void SetQuery(Query* query) { query_ = query; }
 
 	static void SetLogCookies(bool log) { logCookies_ = log; }
@@ -145,19 +145,19 @@ public:
 
 private:
 	static uint8_t buffer_[MAXIMUM_MTU_SIZE];
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 	static char authkeyBuffer_[AUTHKEY_RESPONSE_LEN];
 	static bool connectAsNpc_;
 #endif
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	static uint32_t token_;
 #endif
 	static uint16_t portNumber;
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	static Query *query_;
 #endif
 	static unsigned int timeout_;
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	static bool logCookies_;
     static unsigned int minConnectionTime_;
     static unsigned int messagesLimit_;

--- a/SAMPRakNet.hpp
+++ b/SAMPRakNet.hpp
@@ -33,8 +33,6 @@ typedef int SOCKET;
 
 #define LOCALHOST (0x0100007fu)
 
-#include <shared_mutex>
-
 class SAMPRakNet
 {
 public:

--- a/SAMPRakNet.hpp
+++ b/SAMPRakNet.hpp
@@ -24,7 +24,13 @@ typedef int SOCKET;
 
 #define MAX_AUTH_RESPONSE_LEN (64)
 
+#ifdef BUILD_FOR_CLIENT
+#define AUTHKEY_RESPONSE_LEN (40)
+#endif
+
+#ifndef BUILD_FOR_CLIENT
 #include "../../Server/Components/LegacyNetwork/Query/query.hpp"
+#endif
 
 #include "Include/raknet/NetworkTypes.h"
 #include "Include/raknet/GetTime.h"
@@ -36,6 +42,7 @@ typedef int SOCKET;
 class SAMPRakNet
 {
 public:
+#ifndef BUILD_FOR_CLIENT
 	enum AuthType {
 		AuthType_Invalid,
 		AuthType_Player,
@@ -55,6 +62,7 @@ public:
 		core_ = core;
 		srand(time(nullptr));
 	}
+#endif
 
 	static uint8_t * Decrypt(uint8_t const * src, int len);
 	static uint8_t * Encrypt(uint8_t const * src, int len);
@@ -62,6 +70,11 @@ public:
 	static uint16_t GetPort();
 	static void SetPort(uint16_t value);
 
+#ifdef BUILD_FOR_CLIENT
+	static char * PrepareAuthkeyResponse(const char* initialKey);
+#endif
+
+#ifndef BUILD_FOR_CLIENT
 	static uint32_t GetToken() { return token_; }
 	static void SeedToken() { token_ = rand(); }
 
@@ -72,10 +85,17 @@ public:
 
 	static void SeedCookie();
 	static uint16_t GetCookie(unsigned int address);
+#endif
 
 	static void SetTimeout(unsigned int timeout) { timeout_ = timeout; }
 	static unsigned int GetTimeout() { return timeout_; }
 
+#ifdef BUILD_FOR_CLIENT
+	static void SetConnectionAsNpc(bool enabled) { connectAsNpc_ = enabled; }
+	static bool ShouldConnectAsNpc() { return connectAsNpc_; }
+#endif
+
+#ifndef BUILD_FOR_CLIENT
 	static void SetQuery(Query* query) { query_ = query; }
 
 	static void SetLogCookies(bool log) { logCookies_ = log; }
@@ -121,13 +141,23 @@ public:
 		RakNet::RakNetTime& minConnectionTick,
 		RakNet::RakNetTime& minConnectionLogTick
 	);
+#endif
 
 private:
 	static uint8_t buffer_[MAXIMUM_MTU_SIZE];
+#ifdef BUILD_FOR_CLIENT
+	static char authkeyBuffer_[AUTHKEY_RESPONSE_LEN];
+	static bool connectAsNpc_;
+#endif
+#ifndef BUILD_FOR_CLIENT
 	static uint32_t token_;
+#endif
 	static uint16_t portNumber;
+#ifndef BUILD_FOR_CLIENT
 	static Query *query_;
+#endif
 	static unsigned int timeout_;
+#ifndef BUILD_FOR_CLIENT
 	static bool logCookies_;
     static unsigned int minConnectionTime_;
     static unsigned int messagesLimit_;
@@ -137,4 +167,5 @@ private:
 	static ICore* core_;
 	static FlatHashSet<uint32_t> incomingConnections_;
 	static RakNet::RakNetTime gracePeriod_;
+#endif
 };

--- a/Source/RakPeer.cpp
+++ b/Source/RakPeer.cpp
@@ -2684,7 +2684,7 @@ RakPeer::RemoteSystemStruct *RakPeer::GetRemoteSystemFromPlayerID( const PlayerI
 
 	return 0;
 }
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 // --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 void RakPeer::ParseConnectionRequestPacket( RakPeer::RemoteSystemStruct *remoteSystem, PlayerID playerId, const char *data, int byteSize )
 {
@@ -3526,7 +3526,7 @@ void RakPeer::CloseConnectionInternal( const PlayerID target, bool sendDisconnec
 					// Found the index to stop
 					remoteSystem->isActive = false;
 					--activePeersCount;
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 					SAMPRakNet::SetRequestingConnection(target.binaryAddress, false);
 #endif
 
@@ -3909,7 +3909,7 @@ namespace RakNet
 	
 	}
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	bool __stdcall ProcessBan(RakPeer* rakPeer, PlayerID playerId, const char* data, const int length)
 	{
 		if (rakPeer->IsBanned(rakPeer->PlayerIDToDottedIP(playerId)))
@@ -3939,7 +3939,7 @@ namespace RakNet
 	void ProcessNetworkPacket( const unsigned int binaryAddress, const unsigned short port, const char *data, const int length, RakPeer *rakPeer )
 	#endif
 	{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		static RakNetTime minConnectionTick;
 		static RakNetTime minConnectionLogTick;
 #endif
@@ -3951,7 +3951,7 @@ namespace RakNet
 		playerId.binaryAddress = binaryAddress;
 		playerId.port = port;
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		const bool needsBanCheck = (data[0] == ID_OPEN_CONNECTION_REQUEST || data[0] == ID_OPEN_CONNECTION_REPLY || data[0] == ID_CONNECTION_ATTEMPT_FAILED);
 
 	#if !defined(_COMPATIBILITY_1)
@@ -4111,7 +4111,7 @@ namespace RakNet
 		// Therefore, this datagram must be under 17 bits - otherwise it may be normal network traffic as the min size for a raknet send is 17 bits
 		else if ((unsigned char)(data)[0] == ID_OPEN_CONNECTION_REQUEST && length == sizeof(unsigned char)*3)
 		{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			if (!SAMPRakNet::OnConnectionRequest(rakPeer->connectionSocket, playerId, data, minConnectionTick, minConnectionLogTick))
 			{
 				return;
@@ -4123,13 +4123,13 @@ namespace RakNet
 
 			// If this guy is already connected and they initiated the connection, ignore the connection request
 			RakPeer::RemoteSystemStruct *rss = rakPeer->GetRemoteSystemFromPlayerID( playerId, true, true );
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			static unsigned int s_uiLastProcessedBinaryAddr = 0;
 			static unsigned int s_uiLastProcessedConnTick = 0;
 #endif
 			if (rss==0 || rss->weInitiatedTheConnection==true)
 			{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 				if (rakPeer->GetNumberOfUnverifiedInstances(binaryAddress) > 30)
 				{
 					SAMPRakNet::GetCore()->printLn("Blocking %s due to a 'server full' attack (1)", playerId.ToString());
@@ -4156,7 +4156,7 @@ namespace RakNet
 				unsigned char c[2];
 				if (rss) // If this guy is already connected remote system will be 0
 				{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 					s_uiLastProcessedBinaryAddr = playerId.binaryAddress;
 					s_uiLastProcessedConnTick = RakNet::GetTime();
 #endif
@@ -4171,7 +4171,7 @@ namespace RakNet
 					rakPeer->messageHandlerList[i]->OnDirectSocketSend((char*)&c, 16, playerId);
 				SocketLayer::Instance()->SendTo( rakPeer->connectionSocket, (char*)&c, 2, playerId.binaryAddress, playerId.port );
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 				if (rss)
 				{
 					SAMPRakNet::SetRequestingConnection(binaryAddress, true);
@@ -4199,7 +4199,7 @@ namespace RakNet
 			}
 
 		}
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 		// SAMP clientside connection cookie verification
 		else if ((unsigned char)(data)[0] == ID_OPEN_CONNECTION_COOKIE && length == sizeof(unsigned char)*3)
 		{
@@ -4306,7 +4306,7 @@ namespace RakNet
 				}
 			}
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			if (shouldBanPeer && playerId.binaryAddress != LOCALHOST && GetTime() > SAMPRakNet::GetGracePeriod())
 			{
 				const char* playerIp = rakPeer->PlayerIDToDottedIP(playerId);
@@ -4318,7 +4318,7 @@ namespace RakNet
 		}
 		else
 		{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			if (ProcessBan(rakPeer, playerId, data, length))
 			{
 				return;
@@ -4433,7 +4433,7 @@ namespace RakNet
 					if ( errorCode != 0 && endThreads == false )
 					{
 	#ifdef _DO_PRINTF
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 						SAMPRakNet::GetCore()->printLn( "Server RecvFrom critical failure!" );
 #else
 						printf( "Server RecvFrom critical failure!\n" );
@@ -4660,7 +4660,7 @@ namespace RakNet
 					// }
 					// else connection shutting down, don't bother telling the user
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	#ifdef _DO_PRINTF
 					const char* ipPort = playerId.ToString(true);
 					SAMPRakNet::GetCore()->printLn("Connection dropped for player %s", ipPort);
@@ -4700,7 +4700,7 @@ namespace RakNet
 				// Ping this guy if it is time to do so
 				if ( remoteSystem->connectMode==RemoteSystemStruct::CONNECTED )
 				{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 					// Taken from SA-MP 0.3.7 changes
 					if (!remoteSystem->isLogon)
 					{
@@ -4778,12 +4778,12 @@ namespace RakNet
 					{
 						if ( (unsigned char)(data)[0] == ID_CONNECTION_REQUEST )
 						{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 							ParseConnectionRequestPacket(remoteSystem, playerId, (const char*)data, byteSize);
 #endif
 							delete [] data;
 						}
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 						else if ((unsigned char)(data)[0] != ID_AUTH_KEY || !ParseConnectionAuthPacket(remoteSystem, playerId, data, byteSize))
 						{
 							if ((unsigned char)(data)[0] == ID_RPC && remoteSystem->sampData.unverifiedRPCs++ < MAX_UNVERIFIED_RPCS)
@@ -4815,7 +4815,7 @@ namespace RakNet
 									delete[] data;
 							}
 						}
-#else // !BUILD_FOR_CLIENT
+#else // !RAKNET_BUILD_FOR_CLIENT
 						else
 						{
 							CloseConnectionInternal(playerId, false, true, 0);
@@ -4836,7 +4836,7 @@ namespace RakNet
 						{
 							// 04/27/06 This is wrong.  With cross connections, we can both have initiated the connection are in state REQUESTED_CONNECTION
 							// 04/28/06 Downgrading connections from connected will close the connection due to security at ((remoteSystem->connectMode!=RemoteSystemStruct::CONNECTED && time > remoteSystem->connectionTime && time - remoteSystem->connectionTime > 10000))
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 							if (remoteSystem->connectMode!=RemoteSystemStruct::CONNECTED)
 								ParseConnectionRequestPacket(remoteSystem, playerId, (const char*)data, byteSize);
 #endif
@@ -4854,7 +4854,7 @@ namespace RakNet
 								playerId==myPlayerId) // local system connect
 							{
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 								SAMPRakNet::SetRequestingConnection(playerId.binaryAddress, false);
 #endif
 
@@ -5052,7 +5052,7 @@ namespace RakNet
 									AESKey[ i ] = data[ 1 + i ] ^ ( ( unsigned char* ) ( message ) ) [ i ];
 
 								// Connect this player assuming we have open slots
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 								OnConnectionRequest( remoteSystem, AESKey, true );
 #endif
 							}
@@ -5159,7 +5159,7 @@ namespace RakNet
 								// Tell the remote system the connection failed
 								NotifyAndFlagForDisconnect(playerId, true, 0);
 	#ifdef _DO_PRINTF
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 								SAMPRakNet::GetCore()->printLn( "Error: Got a connection accept when we didn't request the connection." );
 #else
 								printf( "Error: Got a connection accept when we didn't request the connection.\n" );
@@ -5169,7 +5169,7 @@ namespace RakNet
 									delete [] data;
 							}
 						}
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 						else if ( (unsigned char)(data)[0] == ID_AUTH_KEY && byteSize >= sizeof(unsigned char)*4 )
 						{
 							RakNet::BitStream inBitStream( (unsigned char *) data, byteSize, false );

--- a/Source/ReliabilityLayer.cpp
+++ b/Source/ReliabilityLayer.cpp
@@ -346,9 +346,11 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 
 	shouldBanPeer = false;
 	//int numberOfAcksInFrame = 0;
+#ifndef BUILD_FOR_CLIENT
 	unsigned int acksLimit = 0;
 	unsigned int messageHoleLimit = 0;
 	unsigned int messagesLimit = 0;
+#endif
 	RakNetTimeNS time;
 	bool indexFound;
 	int count, size;
@@ -379,9 +381,11 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 
 	RakNet::BitStream socketData( (unsigned char*) buffer, length, false ); // Convert the incoming data to a bitstream for easy parsing
 	time = RakNet::GetTimeNS();
+#ifndef BUILD_FOR_CLIENT
 	acksLimit = SAMPRakNet::GetAcksLimit();
 	messageHoleLimit = SAMPRakNet::GetMessageHoleLimit();
 	messagesLimit = SAMPRakNet::GetMessagesLimit();
+#endif
 
 	DataStructures::RangeList<MessageNumberType> incomingAcks;
 	socketData.Read(hasAcks);
@@ -400,6 +404,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 
 			statistics.acknowlegementsReceived += incomingAcks.ranges[i].maxIndex - incomingAcks.ranges[i].minIndex;
 
+#ifndef BUILD_FOR_CLIENT
 			if (incomingAcks.ranges[i].maxIndex - incomingAcks.ranges[i].minIndex > messageHoleLimit)
 			{
 				unsigned int receivedAcks = incomingAcks.ranges[i].maxIndex - incomingAcks.ranges[i].minIndex;
@@ -409,6 +414,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				shouldBanPeer = true;
 				return 1;
 			}
+#endif
 
 			for (messageNumber=incomingAcks.ranges[i].minIndex; messageNumber >= incomingAcks.ranges[i].minIndex && messageNumber <= incomingAcks.ranges[i].maxIndex; messageNumber++)
 			{
@@ -451,6 +457,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				statistics.perFrameAcksLimitCounter = 0;
 			}
 			
+#ifndef BUILD_FOR_CLIENT
 			if (statistics.perSecondAcksLimitCounter > acksLimit)
 			{
 				const char * ipPort = playerId.ToString(true);
@@ -459,6 +466,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				shouldBanPeer = true;
 				return 1;
 			}
+#endif
 
 		}
 	}
@@ -590,6 +598,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				statistics.perSecondMessagesLimitCounter = statistics.perFrameMessagesLimitCounter;
 				statistics.perFrameMessagesLimitCounter = 0;
 			}
+#ifndef BUILD_FOR_CLIENT
 			if (statistics.perSecondMessagesLimitCounter > messagesLimit)
 			{
 				const char* ipPort = playerId.ToString(true);
@@ -598,6 +607,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				shouldBanPeer = true;
 				return 1;
 			}
+#endif
 
 			statistics.messagesReceived++;
 			if (time - statistics.lastRecvMsgProcess > 1000000)
@@ -800,6 +810,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				//	RakAssert(waitingForOrderedPacketReadIndex[ internalPacket->orderingChannel ] < internalPacket->orderingIndex);
 					statistics.orderedMessagesOutOfOrder++;
 
+#ifndef BUILD_FOR_CLIENT
 					if (statistics.orderedMessagesOutOfOrder > messageHoleLimit)
 					{
 						const char* ipPort = playerId.ToString(true);
@@ -808,6 +819,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 						shouldBanPeer = true;
 						return 1;
 					}
+#endif
 
 					// This is a newer ordered packet than we are waiting for. Store it for future use
 					AddToOrderingList( internalPacket );
@@ -1944,7 +1956,9 @@ InternalPacket* ReliabilityLayer::CreateInternalPacketFromBitStream( RakNet::Bit
 			return 0;
 		}
 
+#ifndef BUILD_FOR_CLIENT
 		SAMPRakNet::GetCore()->logLn(LogLevel::Warning, "dropping a split packet from client");
+#endif
 		internalPacketPool.ReleasePointer(internalPacket);
 	}
 	else

--- a/Source/ReliabilityLayer.cpp
+++ b/Source/ReliabilityLayer.cpp
@@ -346,7 +346,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 
 	shouldBanPeer = false;
 	//int numberOfAcksInFrame = 0;
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	unsigned int acksLimit = 0;
 	unsigned int messageHoleLimit = 0;
 	unsigned int messagesLimit = 0;
@@ -381,7 +381,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 
 	RakNet::BitStream socketData( (unsigned char*) buffer, length, false ); // Convert the incoming data to a bitstream for easy parsing
 	time = RakNet::GetTimeNS();
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 	acksLimit = SAMPRakNet::GetAcksLimit();
 	messageHoleLimit = SAMPRakNet::GetMessageHoleLimit();
 	messagesLimit = SAMPRakNet::GetMessagesLimit();
@@ -404,7 +404,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 
 			statistics.acknowlegementsReceived += incomingAcks.ranges[i].maxIndex - incomingAcks.ranges[i].minIndex;
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			if (incomingAcks.ranges[i].maxIndex - incomingAcks.ranges[i].minIndex > messageHoleLimit)
 			{
 				unsigned int receivedAcks = incomingAcks.ranges[i].maxIndex - incomingAcks.ranges[i].minIndex;
@@ -457,7 +457,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				statistics.perFrameAcksLimitCounter = 0;
 			}
 			
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			if (statistics.perSecondAcksLimitCounter > acksLimit)
 			{
 				const char * ipPort = playerId.ToString(true);
@@ -598,7 +598,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				statistics.perSecondMessagesLimitCounter = statistics.perFrameMessagesLimitCounter;
 				statistics.perFrameMessagesLimitCounter = 0;
 			}
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 			if (statistics.perSecondMessagesLimitCounter > messagesLimit)
 			{
 				const char* ipPort = playerId.ToString(true);
@@ -810,7 +810,7 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer( const char *buffe
 				//	RakAssert(waitingForOrderedPacketReadIndex[ internalPacket->orderingChannel ] < internalPacket->orderingIndex);
 					statistics.orderedMessagesOutOfOrder++;
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 					if (statistics.orderedMessagesOutOfOrder > messageHoleLimit)
 					{
 						const char* ipPort = playerId.ToString(true);
@@ -1956,7 +1956,7 @@ InternalPacket* ReliabilityLayer::CreateInternalPacketFromBitStream( RakNet::Bit
 			return 0;
 		}
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		SAMPRakNet::GetCore()->logLn(LogLevel::Warning, "dropping a split packet from client");
 #endif
 		internalPacketPool.ReleasePointer(internalPacket);

--- a/Source/SocketLayer.cpp
+++ b/Source/SocketLayer.cpp
@@ -368,14 +368,17 @@ int SocketLayer::RecvFrom( const SOCKET s, RakPeer *rakPeer, int *errorCode )
 
 	if ( len != SOCKET_ERROR )
 	{
+#ifndef BUILD_FOR_CLIENT
 		if (len > 10 && data[0] == 'S' && data[1] == 'A' && data[2] == 'M' && data[3] == 'P')
 		{
 			SAMPRakNet::HandleQuery(s, len2, sa, data, len);
 			return 1;
 		}
+#endif
 
 		unsigned short portnum;
 		portnum = ntohs( sa.sin_port );
+#ifndef BUILD_FOR_CLIENT
 		uint8_t* decrypted = SAMPRakNet::Decrypt((uint8_t*)data, len);
 		if (decrypted) {
 			ProcessNetworkPacket(sa.sin_addr.s_addr, portnum, (char*)decrypted, len - 1, rakPeer);
@@ -385,6 +388,9 @@ int SocketLayer::RecvFrom( const SOCKET s, RakPeer *rakPeer, int *errorCode )
 			uint8_t* const addr = reinterpret_cast<uint8_t*>(&sa.sin_addr.s_addr);
 			SAMPRakNet::GetCore()->printLn("Dropping bad packet from %u.%u.%u.%u:%u!", addr[0], addr[1], addr[2], addr[3], sa.sin_port);
 		}
+#endif
+#else // BUILD_FOR_CLIENT
+		ProcessNetworkPacket(sa.sin_addr.s_addr, portnum, data, len, rakPeer);
 #endif
 		return 1;
 	}
@@ -451,6 +457,10 @@ int SocketLayer::SendTo( SOCKET s, const char *data, int length, unsigned int bi
 	sa.sin_addr.s_addr = binaryAddress;
 	sa.sin_family = AF_INET;
 
+#ifdef BUILD_FOR_CLIENT
+	data = (const char*)SAMPRakNet::Encrypt((uint8_t*)data, length);
+	length++;
+#endif
 	do
 	{
 		// TODO - use WSASendTo which is faster.

--- a/Source/SocketLayer.cpp
+++ b/Source/SocketLayer.cpp
@@ -368,7 +368,7 @@ int SocketLayer::RecvFrom( const SOCKET s, RakPeer *rakPeer, int *errorCode )
 
 	if ( len != SOCKET_ERROR )
 	{
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		if (len > 10 && data[0] == 'S' && data[1] == 'A' && data[2] == 'M' && data[3] == 'P')
 		{
 			SAMPRakNet::HandleQuery(s, len2, sa, data, len);
@@ -378,7 +378,7 @@ int SocketLayer::RecvFrom( const SOCKET s, RakPeer *rakPeer, int *errorCode )
 
 		unsigned short portnum;
 		portnum = ntohs( sa.sin_port );
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 		uint8_t* decrypted = SAMPRakNet::Decrypt((uint8_t*)data, len);
 		if (decrypted) {
 			ProcessNetworkPacket(sa.sin_addr.s_addr, portnum, (char*)decrypted, len - 1, rakPeer);
@@ -389,7 +389,7 @@ int SocketLayer::RecvFrom( const SOCKET s, RakPeer *rakPeer, int *errorCode )
 			SAMPRakNet::GetCore()->printLn("Dropping bad packet from %u.%u.%u.%u:%u!", addr[0], addr[1], addr[2], addr[3], sa.sin_port);
 		}
 #endif
-#else // BUILD_FOR_CLIENT
+#else // RAKNET_BUILD_FOR_CLIENT
 		ProcessNetworkPacket(sa.sin_addr.s_addr, portnum, data, len, rakPeer);
 #endif
 		return 1;
@@ -457,7 +457,7 @@ int SocketLayer::SendTo( SOCKET s, const char *data, int length, unsigned int bi
 	sa.sin_addr.s_addr = binaryAddress;
 	sa.sin_family = AF_INET;
 
-#ifdef BUILD_FOR_CLIENT
+#ifdef RAKNET_BUILD_FOR_CLIENT
 	data = (const char*)SAMPRakNet::Encrypt((uint8_t*)data, length);
 	length++;
 #endif

--- a/Source/rakserver.cpp
+++ b/Source/rakserver.cpp
@@ -459,7 +459,7 @@ RakPeer::RemoteSystemStruct* RakServer::GetRemoteSystemFromPlayerID(const Player
 	return RakPeer::GetRemoteSystemFromPlayerID(playerId, false, false);
 }
 
-#ifndef BUILD_FOR_CLIENT
+#ifndef RAKNET_BUILD_FOR_CLIENT
 SAMPRakNet::RemoteSystemData RakServer::GetSAMPDataFromPlayerID(const PlayerID playerId)
 {
 	RemoteSystemStruct* remoteSystem = RakPeer::GetRemoteSystemFromPlayerID(playerId, false, false);

--- a/Source/rakserver.cpp
+++ b/Source/rakserver.cpp
@@ -459,6 +459,7 @@ RakPeer::RemoteSystemStruct* RakServer::GetRemoteSystemFromPlayerID(const Player
 	return RakPeer::GetRemoteSystemFromPlayerID(playerId, false, false);
 }
 
+#ifndef BUILD_FOR_CLIENT
 SAMPRakNet::RemoteSystemData RakServer::GetSAMPDataFromPlayerID(const PlayerID playerId)
 {
 	RemoteSystemStruct* remoteSystem = RakPeer::GetRemoteSystemFromPlayerID(playerId, false, false);
@@ -468,6 +469,7 @@ SAMPRakNet::RemoteSystemData RakServer::GetSAMPDataFromPlayerID(const PlayerID p
 
 	return remoteSystem->sampData;
 }
+#endif
 
 #ifdef _MSC_VER
 #pragma warning( pop )


### PR DESCRIPTION
* Connection to server is fully working, backward compatibility with server & original client kept working too
* Roughly removed server OMP-SDK support to let client handle without it
* Enable RAKNET_BUILD_FOR_CLIENT to use

Server-side was not tested with this patch, but there shouldn't be any issue as per as nothing was removed from the original code